### PR TITLE
Added mapping of GEOSCF to CRACMM2 species

### DIFF
--- a/aqmbc/examples/definitions/cf/geoscf_cracmm2aero.expr
+++ b/aqmbc/examples/definitions/cf/geoscf_cracmm2aero.expr
@@ -1,0 +1,90 @@
+# Converts GEOS-CF to CMAQ-CRACMM2
+# Expects variables from three files
+# met_tavg_1hr_g1440x721_v36
+# chm_tavg_1hr_g1440x721_v36
+# xgc_tavg_1hr_g1440x721_v36
+# all from https://opendap.nccs.nasa.gov/dods/gmao/geos-cf/assim/
+# ae7 author: Barron H. Henderson
+# Updated October 2024 by Havala Pye for CRACMM version 2
+AALJ = (0.05695 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AALJ.units = 'micrograms/m**3'
+ACAJ = (0.0118 * sala[:] * 0.0314 + 0.0794 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+ACAJ.units = 'micrograms/m**3'
+ACLJ = (0.00945 * dst1[:] * 0.029 + 0.5538 * sala[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ACLJ.units = 'micrograms/m**3'
+ACLK = (0.0119 * (dst2[:] * 0.029 + dst3[:] * 0.029 + dst4[:] * 0.029) + 0.5538 * salc[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ACLK.units = 'micrograms/m**3'
+AECJ = (0.999 * (bcpi[:] * 0.012 + bcpo[:] * 0.012)) * airdens / 0.0289628 * 1e9
+AECJ.units = 'micrograms/m**3'
+AECI = AECJ[:] / 999
+AECI.units = 'micrograms/m**3'
+AFEJ = (0.03355 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AFEJ.units = 'micrograms/m**3'
+AKJ = (0.0114 * sala[:] * 0.0314 + 0.0377 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AKJ.units = 'micrograms/m**3'
+# CRACMM POA-like species, add NCOM mass based on CRACMM species OM/OC
+# OM/OC * I/J split % * OC * Mw of OC * unit conv.
+AROCN2ALKI = 1.39 * (0.001 * (ocpo[:]) * 0.012) * airdens / 0.0289628 * 1e9
+AROCN2ALKI.units = 'micrograms/m**3'
+AROCN2ALKJ = 1.39 * (0.999 * (ocpo[:]) * 0.012 + 0.5 * 0.01075 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AROCN2ALKJ.units = 'micrograms/m**3'
+AROCN2OXY8I = 2.17* (0.001 * (ocpi[:]) * 0.012) * airdens / 0.0289628 * 1e9
+AROCN2OXY8I.units = 'micrograms/m**3'
+AROCN2OXY8J = 2.17* (0.999 * (ocpi[:]) * 0.012 + 0.5 * 0.01075 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AROCN2OXY8J.units = 'micrograms/m**3'
+# Other species
+AMGJ = (0.0368 * sala[:] * 0.0314) * airdens / 0.0289628 * 1e9
+AMGJ.units = 'micrograms/m**3'
+AMNJ = (0.00115 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AMNJ.units = 'micrograms/m**3'
+ANAJ = (0.3086 * sala[:] * 0.0314 + 0.03935 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+ANAJ.units = 'micrograms/m**3'
+ANH4I = (0.01 * nh4[:] * 0.018) * airdens / 0.0289628 * 1e9
+ANH4I.units = 'micrograms/m**3'
+ANH4J = (0.00005 * dst1[:] * 0.029 + 0.99 * nh4[:] * 0.018) * airdens / 0.0289628 * 1e9
+ANH4J.units = 'micrograms/m**3'
+ANO3I = (0.01 * nit[:] * 0.062) * airdens / 0.0289628 * 1e9
+ANO3I.units = 'micrograms/m**3'
+ANO3J = (0.00020 * dst1[:] * 0.029 + 0.99 * nit[:] * 0.062) * airdens / 0.0289628 * 1e9
+ANO3J.units = 'micrograms/m**3'
+ANO3K = (0.0016 * (dst2[:] * 0.029 + dst3[:] * 0.029 + dst4[:] * 0.029) + nits[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ANO3K.units = 'micrograms/m**3'
+AOTHRJ = (0.50219 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+AOTHRJ.units = 'micrograms/m**3'
+ASEACAT = (0.3685 * salc[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ASEACAT.units = 'micrograms/m**3'
+ASIJ = (0.19435 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+ASIJ.units = 'micrograms/m**3'
+ASO4I = (0.01 * so4[:] * 0.096) * airdens / 0.0289628 * 1e9
+ASO4I.units = 'micrograms/m**3'
+ASO4J = (0.99 * so4[:] * 0.096 + msa[:] * 0.096 + 0.0225 * dst1[:] * 0.029 + 0.0776 * sala[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ASO4J.units = 'micrograms/m**3'
+ASO4K = (0.0776 * salc[:] * 0.0314 + 0.02655 * (dst2[:] * 0.029 + dst3[:] * 0.029 + dst4[:] * 0.029) + so4s[:] * 0.0314) * airdens / 0.0289628 * 1e9
+ASO4K.units = 'micrograms/m**3'
+ASOIL = (0.95995 * (dst2[:] * 0.029 + dst3[:] * 0.029 + dst4[:] * 0.029)) * airdens / 0.0289628 * 1e9
+ASOIL.units = 'micrograms/m**3'
+ATIJ = (0.0028 * dst1[:] * 0.029) * airdens / 0.0289628 * 1e9
+ATIJ.units = 'micrograms/m**3'
+# organic species
+# split isoprene SOA evenly across CRACMM isoprene species (all nonvolatile)
+AISO3NOSJ = 0.25 * (isoa1[:] + isoa2[:] + isoa3[:]) * 0.15 * airdens / 0.0289628 * 1e9 
+AISO3NOSJ.units = 'micrograms/m**3'
+AISO3OSJ = 0.25 * (isoa1[:] + isoa2[:] + isoa3[:]) * 0.15 * airdens / 0.0289628 * 1e9 
+AISO3OSJ.units = 'micrograms/m**3'
+AISO4J = 0.25 * (isoa1[:] + isoa2[:] + isoa3[:]) * 0.15 * airdens / 0.0289628 * 1e9 
+AISO4J.units = 'micrograms/m**3'
+AISO5J = 0.25 * (isoa1[:] + isoa2[:] + isoa3[:]) * 0.15 * airdens / 0.0289628 * 1e9 
+AISO5J.units = 'micrograms/m**3'
+AHOMJ =  (tsoa1[:] + tsoa2[:] + tsoa3[:] ) * 0.15 * airdens / 0.0289628 * 1e9
+AHOMJ.units = 'micrograms/m**3'
+AELHOMJ =  (tsoa0[:] * 0.15) * airdens / 0.0289628 * 1e9
+AELHOMJ.units = 'micrograms/m**3'
+# Match CRACMM species of C* and OM/OC
+AROCN2OXY8J = (asoan[:] * 0.15) * airdens / 0.0289628 * 1e9
+AROCN2OXY8J.units = 'micrograms/m**3'
+AROCP0OXY4J = (asoa1[:] * 0.15) * airdens / 0.0289628 * 1e9
+AROCP0OXY4J.units = 'micrograms/m**3'
+AROCP1OXY3J = (asoa2[:] * 0.15) * airdens / 0.0289628 * 1e9
+AROCP1OXY3J.units = 'micrograms/m**3'
+AROCP2OXY2J = (asoa3[:] * 0.15) * airdens / 0.0289628 * 1e9
+AROCP2OXY2J.units = 'micrograms/m**3'

--- a/aqmbc/examples/definitions/cf/geoscf_cracmm2gas.expr
+++ b/aqmbc/examples/definitions/cf/geoscf_cracmm2gas.expr
@@ -1,0 +1,80 @@
+# Converts GEOS-CF to CMAQ
+# Expects variables from three files
+# met_tavg_1hr_g1440x721_v36
+# chm_tavg_1hr_g1440x721_v36
+# xgc_tavg_1hr_g1440x721_v36
+# all from https://opendap.nccs.nasa.gov/dods/gmao/geos-cf/assim/
+# Cb6 author: Barron H. Henderson
+# Updated 11 October 2024 for CRACMM2 by Havala Pye
+ACT = acet * 1e6 # acetone
+ACT.units = 'ppmV'
+ACD = ald2 * 1e6 # acetaldehyde
+ACD.units = 'ppmV'
+HC5 = alk4 * 1e6 # >C4 alkanes
+HC5.units = 'ppmV'
+BRO = bro * 1e6  # not used in CMAQ CRACMM
+BRO.units = 'ppmV'
+ETH = c2h6 * 1e6 # ethane
+ETH.units = 'ppmV'
+HC3 = c3h8 * 1e6 # propane
+HC3.units = 'ppmV'
+CH4 = ch4 * 1e6  # methane
+CH4.units = 'ppmV'
+CLO = clo * 1e6  # not used in CMAQ CRACMM
+CLO.units = 'ppmV'
+CO = co * 1e6
+CO.units = 'ppmV'
+# H2O = h2o * 1e6
+# H2O.units = 'ppmV'
+H2O2 = h2o2 * 1e6
+H2O2.units = 'ppmV'
+HCHO = hcho * 1e6 # formaldehyde
+HCHO.units = 'ppmV'
+HONO = hno2 * 1e6
+HONO.units = 'ppmV'
+HNO3 = hno3 * 1e6
+HNO3.units = 'ppmV'
+HNO4 = hno4 * 1e6
+HNO4.units = 'ppmV'
+CL = cl * 1e6
+CL.units = 'ppmV'
+CL2 = cl2 * 1e6
+CL2.units = 'ppmV'
+HCL = hcl * 1e6
+HCL.units = 'ppmV'
+MPAN = ipmn * 1e6 # isoprene MPAN
+MPAN.units = 'ppmV'
+PPN = (npmn + ppn) * 1e6 # peroxyacetyl nitrate (not isoprene)
+PPN.units = 'ppmV'
+ONIT = (r4n1 + r4n2 ) * 1e6 # organic nitrates
+ONIT.units = 'ppmV'
+HO2 = ho2_mmr * 28.9628 / 33.01 * 1e6
+HO2.units = 'ppmV'
+IO = io * 1e6    # not used in CMAQ CRACMM
+IO.units = 'ppmV'
+ISO = isop * 1e6 # isoprene
+ISO.units = 'ppmV'
+MEK = mek * 1e6
+MEK.units = 'ppmV'
+N2O5 = n2o5 * 1e6
+N2O5.units = 'ppmV'
+NH3 = nh3 * 1e6
+NH3.units = 'ppmV'
+NO = no * 1e6
+NO.units = 'ppmV'
+NO2 = no2 * 1e6
+NO2.units = 'ppmV'
+NOY = noy * 1e6  # lumped reactive nitrogen (not used in CMAQ CRACMM)
+NOY.units = 'ppmV'
+O3 = o3 * 1e6
+O3.units = 'ppmV'
+HO = oh_mmr * 28.9628 / 17.007 * 1e6
+HO.units = 'ppmV'
+PAN = pan * 1e6
+PAN.units = 'ppmV'
+OLT = prpe * 1e6
+OLT.units = 'ppmV'
+ALD = rcho * 1e6 # lumped aldehydes
+ALD.units = 'ppmV'
+SO2 = so2 * 1e6  
+SO2.units = 'ppmV'


### PR DESCRIPTION
Add mapping of GEOSCF species to CRACMM2 for use in CMAQ BCON and ICON creation. CRACMM2 species are defined in [Skipper et al. 2024](https://doi.org/10.5194/acp-24-12903-2024) or inherited from CRACMM1 as defined in [Pye et al. 2023](https://doi.org/10.5194/acp-23-5043-2023). Builds off CB6_ae7 mappings.